### PR TITLE
chore(devops): Add CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,6 @@
+.github/             @orexe/devops
+CODEOWNERS           @orexe/infra
+src/                 @orexe/developers
+*json                @orexe/developers
+.editorconfig        @orexe/developers
+*                    @aortizorexe


### PR DESCRIPTION
This PR sets ownership for key parts of the repository:

Resource | Owner
-- | --
.gitghub | @orexe/devops
CODEOWNERS | @orexe/infra
src/ | @orexe/developers
*json | @orexe/developers
.editorconfig | @orexe/developers
\* | @aortizorexe